### PR TITLE
deprecate the `audit` command

### DIFF
--- a/main.go
+++ b/main.go
@@ -1159,26 +1159,288 @@ func main() {
 		},
 	}
 
-	var auditCmd = &cobra.Command{
-		Use:   "audit",
-		Short: "View secure access logs",
+	var logsCmd = &cobra.Command{
+		Use:   "logs",
+		Short: "View signed and verified vault logs",
 		Run: func(cmd *cobra.Command, args []string) {
 			_, vault, _, err := src_unlockVault()
 			if err != nil {
 				return
 			}
+			limit, _ := cmd.Flags().GetInt("limit")
+
+			historyVerified := src.VerifyHistoryChain(vault)
+			auditLogs, _ := src.GetAuditLogs(0)
+			auditVerified := src.VerifyAuditLogs(auditLogs)
+			lgitCommits, _ := src.GetLGitCommits(0)
+			lgitVerified := src.VerifyLGitCommits(lgitCommits)
+
+			fmt.Println("Vault History")
+			fmt.Println("-------------")
+			printed := 0
+			for i := len(vault.History) - 1; i >= 0; i-- {
+				if limit > 0 && printed >= limit {
+					break
+				}
+				h := vault.History[i]
+				fmt.Printf("%s %-7s %-12s %-28s %s\n", h.Timestamp.Format("2006-01-02 15:04:05"), h.Action, h.Category, h.Identifier, verificationBadge(historyVerified[i]))
+				printed++
+			}
 			if len(vault.History) == 0 {
-				fmt.Println("No audit logs found.")
-				return
+				fmt.Println("No vault history.")
 			}
-			fmt.Println("Timestamp           Action  Category      Identifier")
-			fmt.Println("----------------------------------------------------")
-			for _, h := range vault.History {
-				fmt.Printf("%s %-7s %-12s %s\n", h.Timestamp.Format("2006-01-02 15:04"), h.Action, h.Category, h.Identifier)
+
+			fmt.Println()
+			fmt.Println("Audit Events")
+			fmt.Println("------------")
+			printed = 0
+			for i := len(auditLogs) - 1; i >= 0; i-- {
+				if limit > 0 && printed >= limit {
+					break
+				}
+				a := auditLogs[i]
+				fmt.Printf("%s %-24s %-44s user=%s@%s %s\n", a.Timestamp.Format("2006-01-02 15:04:05"), truncateText(a.Action, 24), truncateText(a.Details, 44), truncateText(a.User, 12), truncateText(a.Hostname, 18), verificationBadge(auditVerified[i]))
+				printed++
 			}
-			src.LogAction("AUDIT_VIEWED", "Audit logs displayed")
+			if len(auditLogs) == 0 {
+				fmt.Println("No audit events.")
+			}
+
+			fmt.Println()
+			fmt.Println("LGit Commits")
+			fmt.Println("------------")
+			printed = 0
+			for i := len(lgitCommits) - 1; i >= 0; i-- {
+				if limit > 0 && printed >= limit {
+					break
+				}
+				c := lgitCommits[i]
+				fmt.Printf("%s %-14s %-8s %s %s\n", c.Timestamp.Format("2006-01-02 15:04:05"), truncateText(c.ID, 14), truncateText(c.Action, 8), truncateText(c.DataHash, 16), verificationBadge(lgitVerified[i]))
+				printed++
+			}
+			if len(lgitCommits) == 0 {
+				fmt.Println("No lgit commits.")
+			}
+
+			src.LogAction("LOGS_VIEWED", "Displayed signed logs")
 		},
 	}
+	logsCmd.Flags().Int("limit", 200, "Maximum records to print per section (0 for all)")
+
+	var lgitCmd = &cobra.Command{
+		Use:   "lgit",
+		Short: "Vault log history controls",
+	}
+
+	var lgitTreeCmd = &cobra.Command{
+		Use:   "tree",
+		Short: "Display signed lgit commit history",
+		Run: func(cmd *cobra.Command, args []string) {
+			limit, _ := cmd.Flags().GetInt("limit")
+			commits, err := src.GetLGitCommits(limit)
+			if err != nil {
+				color.Red("Failed to read lgit history: %v", err)
+				return
+			}
+			if len(commits) == 0 {
+				fmt.Println("No lgit history found.")
+				return
+			}
+			verified := src.VerifyLGitCommits(commits)
+			fmt.Println("Timestamp            ID             Action   Data Hash         Status")
+			fmt.Println("-----------------------------------------------------------------------")
+			for i := len(commits) - 1; i >= 0; i-- {
+				c := commits[i]
+				fmt.Printf("%s %-14s %-8s %-16s %s\n", c.Timestamp.Format("2006-01-02 15:04:05"), truncateText(c.ID, 14), truncateText(c.Action, 8), truncateText(c.DataHash, 16), verificationBadge(verified[i]))
+			}
+		},
+	}
+	lgitTreeCmd.Flags().Int("limit", 200, "Maximum commits to display (0 for all)")
+
+	var lgitLogCmd = &cobra.Command{
+		Use:   "log",
+		Short: "Alias for lgit tree",
+		Run:   lgitTreeCmd.Run,
+	}
+	lgitLogCmd.Flags().Int("limit", 200, "Maximum commits to display (0 for all)")
+
+	var lgitStatusCmd = &cobra.Command{
+		Use:   "status",
+		Short: "Show whether current vault matches lgit HEAD snapshot",
+		Run: func(cmd *cobra.Command, args []string) {
+			hasHistory, headID, headHash, inSync, err := src.LGitStatus(vaultPath)
+			if err != nil {
+				color.Red("Failed to read lgit status: %v", err)
+				return
+			}
+			if !hasHistory {
+				fmt.Println("LGit history: empty")
+				return
+			}
+			fmt.Printf("HEAD:        %s\n", headID)
+			fmt.Printf("HEAD hash:   %s\n", truncateText(headHash, 24))
+			if inSync {
+				fmt.Printf("Vault state: %s\n", color.HiGreenString("clean (matches HEAD)"))
+			} else {
+				fmt.Printf("Vault state: %s\n", color.HiYellowString("modified (differs from HEAD)"))
+			}
+		},
+	}
+
+	var lgitShowCmd = &cobra.Command{
+		Use:   "show [commit-id|head]",
+		Short: "Show details for one lgit commit",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			target := "head"
+			if len(args) > 0 {
+				target = args[0]
+			}
+			commit, idx, err := src.FindLGitCommitByPrefix(target)
+			if err != nil {
+				color.Red("Failed to find commit: %v", err)
+				return
+			}
+			if commit == nil {
+				fmt.Printf("No matching commit found for '%s'.\n", target)
+				return
+			}
+			commits, _ := src.GetLGitCommits(0)
+			verified := src.VerifyLGitCommits(commits)
+			status := "[UNVERIFIED]"
+			if idx >= 0 && idx < len(verified) && verified[idx] {
+				status = "[VERIFIED]"
+			}
+			fmt.Printf("ID:           %s\n", commit.ID)
+			fmt.Printf("Timestamp:    %s\n", commit.Timestamp.Format(time.RFC3339))
+			fmt.Printf("Action:       %s\n", commit.Action)
+			fmt.Printf("Vault Path:   %s\n", commit.VaultPath)
+			fmt.Printf("Data Hash:    %s\n", commit.DataHash)
+			fmt.Printf("Prev Hash:    %s\n", truncateText(commit.PrevHash, 24))
+			fmt.Printf("Chain Hash:   %s\n", commit.Hash)
+			fmt.Printf("Snapshot:     %s\n", commit.SnapshotFile)
+			fmt.Printf("Verification: %s\n", status)
+		},
+	}
+
+	var lgitVerifyCmd = &cobra.Command{
+		Use:   "verify",
+		Short: "Verify cryptographic integrity of lgit history",
+		Run: func(cmd *cobra.Command, args []string) {
+			ok, total, err := src.VerifyLGitHistory()
+			if err != nil {
+				color.Red("Verification failed: %v", err)
+				return
+			}
+			fmt.Printf("Verified commits: %d/%d\n", ok, total)
+			if ok == total {
+				fmt.Println(color.HiGreenString("LGit chain integrity is valid."))
+			} else {
+				fmt.Println(color.HiRedString("LGit chain integrity check failed for one or more commits."))
+			}
+		},
+	}
+
+	var lgitSquashCmd = &cobra.Command{
+		Use:   "squash",
+		Short: "Squash lgit history into a compact chain",
+		Run: func(cmd *cobra.Command, args []string) {
+			_, _, readonly, err := src_unlockVault()
+			if err != nil {
+				return
+			}
+			if readonly {
+				color.Red("Vault is in READ-ONLY mode. Cannot squash lgit history.")
+				return
+			}
+			keep, _ := cmd.Flags().GetInt("keep")
+			if err := src.SquashLGitHistory(vaultPath, keep); err != nil {
+				color.Red("Failed to squash lgit history: %v", err)
+				return
+			}
+			color.Green("LGit history squashed.")
+			src.LogAction("LGIT_SQUASH", fmt.Sprintf("Squashed lgit history, kept=%d", keep))
+		},
+	}
+	lgitSquashCmd.Flags().Int("keep", 1, "Number of latest commits to keep before squash")
+
+	var lgitCheckoutCmd = &cobra.Command{
+		Use:   "checkout [commit-id|head]",
+		Short: "Restore vault to a specific lgit snapshot",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			_, _, readonly, err := src_unlockVault()
+			if err != nil {
+				return
+			}
+			if readonly {
+				color.Red("Vault is in READ-ONLY mode. Cannot checkout.")
+				return
+			}
+			target := "head"
+			if len(args) > 0 {
+				target = args[0]
+			}
+			if err := src.CheckoutLGit(vaultPath, target); err != nil {
+				color.Red("Checkout failed: %v", err)
+				return
+			}
+			color.Green("Restored vault from lgit commit '%s'.", target)
+			src.LogAction("LGIT_CHECKOUT", fmt.Sprintf("Checked out lgit commit=%s", target))
+		},
+	}
+
+	var lgitUndoCmd = &cobra.Command{
+		Use:   "undo",
+		Short: "Undo vault changes by restoring previous lgit snapshot",
+		Run: func(cmd *cobra.Command, args []string) {
+			_, _, readonly, err := src_unlockVault()
+			if err != nil {
+				return
+			}
+			if readonly {
+				color.Red("Vault is in READ-ONLY mode. Cannot undo.")
+				return
+			}
+			steps, _ := cmd.Flags().GetInt("steps")
+			if steps < 1 {
+				steps = 1
+			}
+			for i := 0; i < steps; i++ {
+				if err := src.UndoLGit(vaultPath); err != nil {
+					color.Red("Undo stopped at step %d: %v", i+1, err)
+					return
+				}
+			}
+			color.Green("Undo completed (%d step(s)).", steps)
+			src.LogAction("LGIT_UNDO", fmt.Sprintf("Undid %d lgit change(s)", steps))
+		},
+	}
+	lgitUndoCmd.Flags().Int("steps", 1, "How many changes to undo")
+
+	var lgitPruneCmd = &cobra.Command{
+		Use:   "prune",
+		Short: "Remove orphaned lgit snapshot files not referenced by history",
+		Run: func(cmd *cobra.Command, args []string) {
+			_, _, readonly, err := src_unlockVault()
+			if err != nil {
+				return
+			}
+			if readonly {
+				color.Red("Vault is in READ-ONLY mode. Cannot prune.")
+				return
+			}
+			removed, kept, err := src.PruneLGitSnapshots()
+			if err != nil {
+				color.Red("Prune failed: %v", err)
+				return
+			}
+			color.Green("LGit prune complete. Removed=%d, Kept=%d", removed, kept)
+			src.LogAction("LGIT_PRUNE", fmt.Sprintf("Pruned lgit snapshots removed=%d kept=%d", removed, kept))
+		},
+	}
+
+	lgitCmd.AddCommand(lgitTreeCmd, lgitLogCmd, lgitStatusCmd, lgitShowCmd, lgitVerifyCmd, lgitCheckoutCmd, lgitSquashCmd, lgitUndoCmd, lgitPruneCmd)
 
 	var genCmd = &cobra.Command{
 		Use:   "gen",
@@ -3525,7 +3787,7 @@ func main() {
 		}
 		return filepath.Join(filepath.Dir(vaultPath), "faceid", "models")
 	})
-	rootCmd.AddCommand(addCmd, getCmd, genCmd, modeCmd, sessionCmd, cinfoCmd, auditCmd, trustCmd, totpCmd, importCmd, exportCmd, infoCmd, cloudCmd, healthCmd, policyCmd, spaceCmd, pluginsCmd, setupCmd, unlockCmd, lockCmd, profileCmd, compromiseCmd, authCmd, vocabCmd, loadedCmd, faceidCmd, injectcmd.BuildInjectCmd(src_unlockVault))
+	rootCmd.AddCommand(addCmd, getCmd, genCmd, modeCmd, sessionCmd, cinfoCmd, logsCmd, lgitCmd, trustCmd, totpCmd, importCmd, exportCmd, infoCmd, cloudCmd, healthCmd, policyCmd, spaceCmd, pluginsCmd, setupCmd, unlockCmd, lockCmd, profileCmd, compromiseCmd, authCmd, vocabCmd, loadedCmd, faceidCmd, injectcmd.BuildInjectCmd(src_unlockVault))
 	autofillCmd, _ := autofillcmd.NewAutofillAndVaultCommands(autofillcmd.Options{
 		VaultPath:    &vaultPath,
 		ReadPassword: readPassword,
@@ -4149,6 +4411,26 @@ func readIntWithDefault(label string, defaultVal int) int {
 func readInput() string {
 	input, _ := inputReader.ReadString('\n')
 	return strings.TrimSpace(input)
+}
+
+func truncateText(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	if len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return s[:max]
+	}
+	return s[:max-3] + "..."
+}
+
+func verificationBadge(ok bool) string {
+	if ok {
+		return color.HiGreenString("[VERIFIED]")
+	}
+	return color.HiRedString("[UNVERIFIED]")
 }
 
 func loadIgnoreConfigOrEmpty() src.IgnoreConfig {

--- a/src/audit.go
+++ b/src/audit.go
@@ -1,6 +1,10 @@
 package apm
 
 import (
+	"bufio"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -14,13 +18,30 @@ type AuditEntry struct {
 	Details   string    `json:"details"`
 	User      string    `json:"user"`
 	Hostname  string    `json:"hostname"`
+	PrevHash  string    `json:"prev_hash,omitempty"`
+	Hash      string    `json:"hash,omitempty"`
+	Signature string    `json:"signature,omitempty"`
 }
 
 func getAuditFile() string {
-	configDir, _ := os.UserConfigDir()
-	apmDir := filepath.Join(configDir, "apm")
-	_ = os.MkdirAll(apmDir, 0700)
+	apmDir, _ := getAPMConfigDir()
 	return filepath.Join(apmDir, "audit.json")
+}
+
+func getAuditSigningKey() ([]byte, error) {
+	apmDir, err := getAPMConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	return loadOrCreateSigningKey(filepath.Join(apmDir, "audit_signing.key"))
+}
+
+func getLastAuditHash() string {
+	logs, err := GetAuditLogs(1)
+	if err != nil || len(logs) == 0 {
+		return ""
+	}
+	return logs[len(logs)-1].Hash
 }
 
 func LogAction(action, details string) {
@@ -28,6 +49,7 @@ func LogAction(action, details string) {
 		Timestamp: time.Now(),
 		Action:    action,
 		Details:   details,
+		PrevHash:  getLastAuditHash(),
 	}
 
 	if u, err := os.UserHomeDir(); err == nil {
@@ -35,6 +57,16 @@ func LogAction(action, details string) {
 	}
 	if h, err := os.Hostname(); err == nil {
 		entry.Hostname = h
+	}
+
+	serialized := fmt.Sprintf("%d:%s:%s:%s:%s:%s", entry.Timestamp.UnixNano(), entry.Action, entry.Details, entry.User, entry.Hostname, entry.PrevHash)
+	hash := sha256.Sum256([]byte(serialized))
+	entry.Hash = hex.EncodeToString(hash[:])
+
+	if key, err := getAuditSigningKey(); err == nil {
+		mac := hmac.New(sha256.New, key)
+		mac.Write([]byte(entry.Hash))
+		entry.Signature = hex.EncodeToString(mac.Sum(nil))
 	}
 
 	f, err := os.OpenFile(getAuditFile(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
@@ -63,19 +95,59 @@ func GetAuditLogs(limit int) ([]AuditEntry, error) {
 	defer f.Close()
 
 	var logs []AuditEntry
-	decoder := json.NewDecoder(f)
-	for decoder.More() {
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
 		var entry AuditEntry
-		err := decoder.Decode(&entry)
-		if err == nil {
+		if err := json.Unmarshal(line, &entry); err == nil {
 			logs = append(logs, entry)
 		}
 	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
 
 	if limit > 0 && len(logs) > limit {
-
 		return logs[len(logs)-limit:], nil
 	}
 
 	return logs, nil
+}
+
+func VerifyAuditLogs(logs []AuditEntry) []bool {
+	out := make([]bool, len(logs))
+	key, err := getAuditSigningKey()
+	if err != nil {
+		return out
+	}
+
+	prevHash := ""
+	for i, e := range logs {
+		ok := e.Hash != "" && e.Signature != ""
+		if ok {
+			serialized := fmt.Sprintf("%d:%s:%s:%s:%s:%s", e.Timestamp.UnixNano(), e.Action, e.Details, e.User, e.Hostname, e.PrevHash)
+			hash := sha256.Sum256([]byte(serialized))
+			expectedHash := hex.EncodeToString(hash[:])
+			if !hmac.Equal([]byte(expectedHash), []byte(e.Hash)) {
+				ok = false
+			}
+		}
+		if ok {
+			mac := hmac.New(sha256.New, key)
+			mac.Write([]byte(e.Hash))
+			expectedSig := hex.EncodeToString(mac.Sum(nil))
+			if !hmac.Equal([]byte(expectedSig), []byte(e.Signature)) {
+				ok = false
+			}
+		}
+		if ok && e.PrevHash != "" && e.PrevHash != prevHash {
+			ok = false
+		}
+		out[i] = ok
+		prevHash = e.Hash
+	}
+	return out
 }

--- a/src/lgit.go
+++ b/src/lgit.go
@@ -1,0 +1,398 @@
+package apm
+
+import (
+	"bufio"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type LGitCommit struct {
+	ID           string    `json:"id"`
+	Timestamp    time.Time `json:"timestamp"`
+	Action       string    `json:"action"`
+	VaultPath    string    `json:"vault_path"`
+	DataHash     string    `json:"data_hash"`
+	PrevHash     string    `json:"prev_hash,omitempty"`
+	Hash         string    `json:"hash"`
+	Signature    string    `json:"signature"`
+	SnapshotFile string    `json:"snapshot_file"`
+}
+
+func getLGitFile() string {
+	apmDir, _ := getAPMConfigDir()
+	return filepath.Join(apmDir, "lgit.jsonl")
+}
+
+func getLGitSnapshotDir() string {
+	apmDir, _ := getAPMConfigDir()
+	return filepath.Join(apmDir, "lgit_snapshots")
+}
+
+func getLGitSigningKey() ([]byte, error) {
+	apmDir, err := getAPMConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	return loadOrCreateSigningKey(filepath.Join(apmDir, "lgit_signing.key"))
+}
+
+func GetLGitCommits(limit int) ([]LGitCommit, error) {
+	path := getLGitFile()
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return []LGitCommit{}, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var commits []LGitCommit
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var c LGitCommit
+		if err := json.Unmarshal([]byte(line), &c); err == nil {
+			commits = append(commits, c)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	if limit > 0 && len(commits) > limit {
+		return commits[len(commits)-limit:], nil
+	}
+	return commits, nil
+}
+
+func GetLGitHead() (*LGitCommit, error) {
+	commits, err := GetLGitCommits(1)
+	if err != nil {
+		return nil, err
+	}
+	if len(commits) == 0 {
+		return nil, nil
+	}
+	head := commits[len(commits)-1]
+	return &head, nil
+}
+
+func FindLGitCommitByPrefix(prefix string) (*LGitCommit, int, error) {
+	commits, err := GetLGitCommits(0)
+	if err != nil {
+		return nil, -1, err
+	}
+	if len(commits) == 0 {
+		return nil, -1, nil
+	}
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" || strings.EqualFold(prefix, "head") {
+		last := commits[len(commits)-1]
+		return &last, len(commits) - 1, nil
+	}
+
+	match := -1
+	for i := range commits {
+		if strings.HasPrefix(commits[i].ID, prefix) {
+			if match != -1 {
+				return nil, -1, fmt.Errorf("ambiguous commit prefix '%s'", prefix)
+			}
+			match = i
+		}
+	}
+	if match == -1 {
+		return nil, -1, nil
+	}
+	found := commits[match]
+	return &found, match, nil
+}
+
+func VerifyLGitCommits(commits []LGitCommit) []bool {
+	out := make([]bool, len(commits))
+	key, err := getLGitSigningKey()
+	if err != nil {
+		return out
+	}
+	prevHash := ""
+	for i, c := range commits {
+		ok := c.Hash != "" && c.Signature != ""
+		if ok {
+			content := fmt.Sprintf("%s:%d:%s:%s:%s:%s:%s", c.ID, c.Timestamp.UnixNano(), c.Action, c.VaultPath, c.DataHash, c.PrevHash, c.SnapshotFile)
+			sum := sha256.Sum256([]byte(content))
+			expectedHash := hex.EncodeToString(sum[:])
+			if !hmac.Equal([]byte(expectedHash), []byte(c.Hash)) {
+				ok = false
+			}
+		}
+		if ok {
+			mac := hmac.New(sha256.New, key)
+			mac.Write([]byte(c.Hash))
+			expectedSig := hex.EncodeToString(mac.Sum(nil))
+			if !hmac.Equal([]byte(expectedSig), []byte(c.Signature)) {
+				ok = false
+			}
+		}
+		if ok && c.PrevHash != "" && c.PrevHash != prevHash {
+			ok = false
+		}
+		out[i] = ok
+		prevHash = c.Hash
+	}
+	return out
+}
+
+func VerifyLGitHistory() (int, int, error) {
+	commits, err := GetLGitCommits(0)
+	if err != nil {
+		return 0, 0, err
+	}
+	flags := VerifyLGitCommits(commits)
+	ok := 0
+	for _, v := range flags {
+		if v {
+			ok++
+		}
+	}
+	return ok, len(commits), nil
+}
+
+func RecordLGitCommit(vaultPath string, data []byte, action string) error {
+	if len(data) == 0 {
+		return nil
+	}
+
+	if action == "" {
+		action = "SAVE"
+	}
+
+	all, err := GetLGitCommits(0)
+	if err != nil {
+		return err
+	}
+
+	dataSum := sha256.Sum256(data)
+	dataHash := hex.EncodeToString(dataSum[:])
+
+	prevHash := ""
+	if n := len(all); n > 0 {
+		prev := all[n-1]
+		prevHash = prev.Hash
+		if prev.DataHash == dataHash && prev.VaultPath == vaultPath && action == "SAVE" {
+			return nil
+		}
+	}
+
+	if err := os.MkdirAll(getLGitSnapshotDir(), 0700); err != nil {
+		return err
+	}
+
+	now := time.Now().UTC()
+	id := fmt.Sprintf("%d-%s", now.UnixNano(), dataHash[:12])
+	snapshotFile := filepath.Join(getLGitSnapshotDir(), id+".vault")
+	if err := os.WriteFile(snapshotFile, data, 0600); err != nil {
+		return err
+	}
+
+	commit := LGitCommit{
+		ID:           id,
+		Timestamp:    now,
+		Action:       action,
+		VaultPath:    vaultPath,
+		DataHash:     dataHash,
+		PrevHash:     prevHash,
+		SnapshotFile: snapshotFile,
+	}
+
+	content := fmt.Sprintf("%s:%d:%s:%s:%s:%s:%s", commit.ID, commit.Timestamp.UnixNano(), commit.Action, commit.VaultPath, commit.DataHash, commit.PrevHash, commit.SnapshotFile)
+	sum := sha256.Sum256([]byte(content))
+	commit.Hash = hex.EncodeToString(sum[:])
+
+	key, err := getLGitSigningKey()
+	if err != nil {
+		return err
+	}
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(commit.Hash))
+	commit.Signature = hex.EncodeToString(mac.Sum(nil))
+
+	f, err := os.OpenFile(getLGitFile(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	line, _ := json.Marshal(commit)
+	_, err = f.WriteString(string(line) + "\n")
+	return err
+}
+
+func CheckoutLGit(vaultPath string, commitPrefix string) error {
+	commit, _, err := FindLGitCommitByPrefix(commitPrefix)
+	if err != nil {
+		return err
+	}
+	if commit == nil {
+		return fmt.Errorf("commit '%s' not found", commitPrefix)
+	}
+
+	data, err := os.ReadFile(commit.SnapshotFile)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(vaultPath, data, 0600); err != nil {
+		return err
+	}
+	return RecordLGitCommit(vaultPath, data, "CHECKOUT")
+}
+
+func SquashLGitHistory(vaultPath string, keep int) error {
+	if keep < 1 {
+		keep = 1
+	}
+	commits, err := GetLGitCommits(0)
+	if err != nil {
+		return err
+	}
+	if len(commits) <= keep {
+		return nil
+	}
+
+	keepFrom := len(commits) - keep
+	for _, c := range commits[:keepFrom] {
+		if c.SnapshotFile != "" {
+			_ = os.Remove(c.SnapshotFile)
+		}
+	}
+
+	kept := commits[keepFrom:]
+	if err := rewriteLGitChain(kept); err != nil {
+		return err
+	}
+
+	latest, err := os.ReadFile(kept[len(kept)-1].SnapshotFile)
+	if err != nil {
+		return err
+	}
+	return RecordLGitCommit(vaultPath, latest, "SQUASH")
+}
+
+func UndoLGit(vaultPath string) error {
+	commits, err := GetLGitCommits(0)
+	if err != nil {
+		return err
+	}
+	if len(commits) < 2 {
+		return fmt.Errorf("not enough lgit history to undo")
+	}
+
+	target := commits[len(commits)-2]
+	data, err := os.ReadFile(target.SnapshotFile)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(vaultPath, data, 0600); err != nil {
+		return err
+	}
+	return RecordLGitCommit(vaultPath, data, "UNDO")
+}
+
+func LGitStatus(vaultPath string) (bool, string, string, bool, error) {
+	head, err := GetLGitHead()
+	if err != nil {
+		return false, "", "", false, err
+	}
+	if head == nil {
+		return false, "", "", false, nil
+	}
+
+	data, err := os.ReadFile(vaultPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, head.ID, head.DataHash, false, nil
+		}
+		return true, head.ID, head.DataHash, false, err
+	}
+	sum := sha256.Sum256(data)
+	currentHash := hex.EncodeToString(sum[:])
+	return true, head.ID, head.DataHash, currentHash == head.DataHash, nil
+}
+
+func PruneLGitSnapshots() (int, int, error) {
+	commits, err := GetLGitCommits(0)
+	if err != nil {
+		return 0, 0, err
+	}
+	keep := make(map[string]struct{}, len(commits))
+	for _, c := range commits {
+		if c.SnapshotFile != "" {
+			keep[c.SnapshotFile] = struct{}{}
+		}
+	}
+
+	files, err := os.ReadDir(getLGitSnapshotDir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, 0, nil
+		}
+		return 0, 0, err
+	}
+
+	removed := 0
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		path := filepath.Join(getLGitSnapshotDir(), file.Name())
+		if _, ok := keep[path]; ok {
+			continue
+		}
+		if err := os.Remove(path); err == nil {
+			removed++
+		}
+	}
+
+	return removed, len(files) - removed, nil
+}
+
+func rewriteLGitChain(commits []LGitCommit) error {
+	if len(commits) == 0 {
+		return os.WriteFile(getLGitFile(), nil, 0600)
+	}
+
+	key, err := getLGitSigningKey()
+	if err != nil {
+		return err
+	}
+
+	prevHash := ""
+	for i := range commits {
+		commits[i].PrevHash = prevHash
+		content := fmt.Sprintf("%s:%d:%s:%s:%s:%s:%s", commits[i].ID, commits[i].Timestamp.UnixNano(), commits[i].Action, commits[i].VaultPath, commits[i].DataHash, commits[i].PrevHash, commits[i].SnapshotFile)
+		sum := sha256.Sum256([]byte(content))
+		commits[i].Hash = hex.EncodeToString(sum[:])
+
+		mac := hmac.New(sha256.New, key)
+		mac.Write([]byte(commits[i].Hash))
+		commits[i].Signature = hex.EncodeToString(mac.Sum(nil))
+		prevHash = commits[i].Hash
+	}
+
+	var b strings.Builder
+	for _, c := range commits {
+		line, _ := json.Marshal(c)
+		b.Write(line)
+		b.WriteByte('\n')
+	}
+	return os.WriteFile(getLGitFile(), []byte(b.String()), 0600)
+}

--- a/src/log_signing.go
+++ b/src/log_signing.go
@@ -1,0 +1,34 @@
+package apm
+
+import (
+	"crypto/rand"
+	"os"
+	"path/filepath"
+)
+
+func getAPMConfigDir() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	apmDir := filepath.Join(configDir, "apm")
+	if err := os.MkdirAll(apmDir, 0700); err != nil {
+		return "", err
+	}
+	return apmDir, nil
+}
+
+func loadOrCreateSigningKey(filePath string) ([]byte, error) {
+	if b, err := os.ReadFile(filePath); err == nil && len(b) >= 32 {
+		return b, nil
+	}
+
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(filePath, key, 0600); err != nil {
+		return nil, err
+	}
+	return key, nil
+}

--- a/src/storage.go
+++ b/src/storage.go
@@ -5,7 +5,11 @@ import (
 )
 
 func SaveVault(path string, data []byte) error {
-	return os.WriteFile(path, data, 0600)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return err
+	}
+	_ = RecordLGitCommit(path, data, "SAVE")
+	return nil
 }
 
 func LoadVault(path string) ([]byte, error) {

--- a/src/vault.go
+++ b/src/vault.go
@@ -236,6 +236,7 @@ type HistoryEntry struct {
 	Action     string    `json:"action"`
 	Category   string    `json:"category"`
 	Identifier string    `json:"identifier"`
+	PrevHash   string    `json:"prev_hash,omitempty"`
 	Hash       string    `json:"hash,omitempty"`
 	Signature  string    `json:"signature,omitempty"`
 }
@@ -1215,14 +1216,20 @@ func DecryptData(data []byte, password string) ([]byte, error) {
 }
 
 func (v *Vault) logHistory(action, category, identifier string) {
+	prevHash := ""
+	if n := len(v.History); n > 0 {
+		prevHash = v.History[n-1].Hash
+	}
+
 	entry := HistoryEntry{
 		Timestamp:  time.Now(),
 		Action:     action,
 		Category:   category,
 		Identifier: identifier,
+		PrevHash:   prevHash,
 	}
 
-	data := fmt.Sprintf("%d:%s:%s:%s", entry.Timestamp.UnixNano(), entry.Action, entry.Category, entry.Identifier)
+	data := fmt.Sprintf("%d:%s:%s:%s:%s", entry.Timestamp.UnixNano(), entry.Action, entry.Category, entry.Identifier, entry.PrevHash)
 	hash := sha256.Sum256([]byte(data))
 	entry.Hash = hex.EncodeToString(hash[:])
 
@@ -1240,6 +1247,43 @@ func (v *Vault) logHistory(action, category, identifier string) {
 	case "DEL":
 		v.RemoveSecretTelemetry(category, identifier)
 	}
+}
+
+func VerifyHistoryEntrySignature(salt []byte, entry HistoryEntry) bool {
+	if entry.Hash == "" || entry.Signature == "" {
+		return false
+	}
+
+	legacyData := fmt.Sprintf("%d:%s:%s:%s", entry.Timestamp.UnixNano(), entry.Action, entry.Category, entry.Identifier)
+	legacyHash := sha256.Sum256([]byte(legacyData))
+	legacyHashHex := hex.EncodeToString(legacyHash[:])
+
+	newData := fmt.Sprintf("%d:%s:%s:%s:%s", entry.Timestamp.UnixNano(), entry.Action, entry.Category, entry.Identifier, entry.PrevHash)
+	newHash := sha256.Sum256([]byte(newData))
+	newHashHex := hex.EncodeToString(newHash[:])
+
+	if entry.Hash != legacyHashHex && entry.Hash != newHashHex {
+		return false
+	}
+
+	mac := hmac.New(sha256.New, salt)
+	mac.Write([]byte(entry.Hash))
+	expectedSig := hex.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(expectedSig), []byte(entry.Signature))
+}
+
+func VerifyHistoryChain(v *Vault) []bool {
+	out := make([]bool, len(v.History))
+	expectedPrev := ""
+	for i, h := range v.History {
+		ok := VerifyHistoryEntrySignature(v.Salt, h)
+		if h.PrevHash != "" && h.PrevHash != expectedPrev {
+			ok = false
+		}
+		out[i] = ok
+		expectedPrev = h.Hash
+	}
+	return out
 }
 
 func (v *Vault) AddEntry(account, username, password string) error {


### PR DESCRIPTION
## Summary
This PR removes the deprecated `pm audit` command and replaces it with a stronger, signed, and verifiable logging system:

- New `pm logs` command that aggregates vault history, audit events, and `lgit` commits.
- Cryptographic signing + verification for logs, with explicit verified/unverified badges.
- New `pm lgit` command group for git-style vault history and recovery operations.

---

## Why
`audit` was limited and did not provide a complete, tamper-evident history across all modifiable vault operations.

This change introduces:

- Unified observability (`logs`)
- Chain-linked signed records
- Operational tooling for history, rollback, and integrity verification (`lgit`)

---

## What Changed

### 1) Removed deprecated `audit` command
- Deleted `pm audit` from the root command tree.
- Introduced `pm logs` as the canonical replacement.

### 2) Added unified `pm logs`
`pm logs` now prints three sections:

1. Vault History
2. Audit Events
3. LGit Commits

Each row includes a verification badge:
- `[VERIFIED]`
- `[UNVERIFIED]`

Flag:
- `--limit` (default: `200`, `0` = all)

### 3) Signed + chain-linked vault history verification
In `src/vault.go`:
- Extended `HistoryEntry` with:
  - `PrevHash string`
- Updated history hashing to include `PrevHash`.
- Added:
  - `VerifyHistoryEntrySignature(...)`
  - `VerifyHistoryChain(...)`

This preserves compatibility with legacy entries by validating both legacy and new hash formats.

### 4) Upgraded audit log to signed records
In `src/audit.go`:
- Extended `AuditEntry` with:
  - `PrevHash string`
  - `Hash string`
  - `Signature string`
- `LogAction(...)` now computes:
  - deterministic hash over entry content
  - HMAC signature over hash
  - chain linkage via `PrevHash`
- `GetAuditLogs(...)` now reads JSONL safely via scanner.
- Added:
  - `VerifyAuditLogs(...)`

### 5) Added signing-key utilities
New file `src/log_signing.go`:
- Shared APM config-dir resolver
- Shared key loader/creator for log signing keys
- Keys are created with secure random bytes and persisted with `0600` permissions

### 6) Added LGit subsystem (`src/lgit.go`)
Introduced signed snapshot commit ledger for vault state.

#### Commit model
`LGitCommit` stores:
- `ID`
- `Timestamp`
- `Action`
- `VaultPath`
- `DataHash`
- `PrevHash`
- `Hash`
- `Signature`
- `SnapshotFile`

#### Added LGit core functions
- `GetLGitCommits(limit int)`
- `GetLGitHead()`
- `FindLGitCommitByPrefix(prefix string)`
- `VerifyLGitCommits(...)`
- `VerifyLGitHistory()`
- `RecordLGitCommit(...)`
- `CheckoutLGit(...)`
- `UndoLGit(...)`
- `SquashLGitHistory(...)`
- `LGitStatus(...)`
- `PruneLGitSnapshots()`

### 7) Auto-commit on vault save
In `src/storage.go`:
- `SaveVault(...)` now records `lgit` `SAVE` commits after successful writes.

### 8) Expanded `pm lgit` command set
In `main.go`, `lgit` now includes:

- `pm lgit tree`
- `pm lgit log` (alias for `tree`)
- `pm lgit status`
- `pm lgit show [commit-id|head]`
- `pm lgit verify`
- `pm lgit checkout [commit-id|head]`
- `pm lgit squash --keep N`
- `pm lgit undo --steps N`
- `pm lgit prune`

And existing:
- verification badges in output
- audit trail events (`LGIT_*`) via `LogAction(...)`

---

## Security & Integrity Notes
- Log chains are append-linked (`PrevHash`) to detect reordering/insertion/tampering.
- Each entry is signed using HMAC-SHA256 over deterministic hash material.
- Verification runs at read-time in `logs` and in `pm lgit verify`.
- Signing keys are stored under user config in `~/.config/apm` (platform equivalent) with `0600` permissions.

---

## Behavioral Notes
- Legacy vault history entries remain readable and verifiable via backward-compatible hash validation.
- Older unsigned audit lines (if present) will show `[UNVERIFIED]`.
- `lgit checkout` and `lgit undo` restore encrypted vault snapshots and then append new signed LGit commits (`CHECKOUT` / `UNDO`).
**Note: Related issue for this PR is #35**
---

## CLI Examples

```bash
# Unified logs
pm logs
pm logs --limit 500
pm logs --limit 0

# LGit history
pm lgit tree
pm lgit log
pm lgit show head
pm lgit show 1766834621-abcd1234

# Integrity
pm lgit verify

# Status against HEAD
pm lgit status

# Restore / rollback
pm lgit checkout head
pm lgit checkout 1766834621-abcd1234
pm lgit undo
pm lgit undo --steps 3

# Cleanup / compaction
pm lgit squash --keep 1
pm lgit prune